### PR TITLE
Switch to python3

### DIFF
--- a/refresh_patches
+++ b/refresh_patches
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2012-2013 SUSE Linux
 #


### PR DESCRIPTION
Switch to python3
because python2 is obsolete and EOL